### PR TITLE
Add base config for BTT SKR Mini E3 v3

### DIFF
--- a/printer-skr-mini-e3-v3.cfg
+++ b/printer-skr-mini-e3-v3.cfg
@@ -1,0 +1,184 @@
+# This file contains pin mappings for the Sovol SV06 using a BigTreeTech SKR Mini v3.0.
+# 
+# Find installation instructions at https://github.com/bassamanator/Sovol-SV06-firmware
+# 
+# See https://www.klipper3d.org/Config_Reference.html for configuration reference.
+
+# Add your includes here
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32g0b0xx_3D0059000E50415833323520-if00
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 45
+
+[stepper_x]
+step_pin: PB13
+dir_pin: PB12
+enable_pin: !PB14
+microsteps: 64
+rotation_distance: 40
+endstop_pin: tmc2209_stepper_x:virtual_endstop
+position_endstop: 0
+position_max: 225
+homing_speed: 100
+homing_retract_dist: 0
+
+[tmc2209 stepper_x]
+uart_pin: PC11
+tx_pin: PC10
+run_current: 0.860
+stealthchop_threshold: 999999
+interpolate: False
+sense_resistor: 0.150
+uart_address: 0
+driver_SGTHRS: 112
+diag_pin: PC0
+
+[stepper_y]
+step_pin: PB10
+dir_pin: !PB2
+enable_pin: !PB11
+microsteps: 64
+rotation_distance: 40
+endstop_pin: tmc2209_stepper_y:virtual_endstop
+position_endstop: 0
+position_max: 225
+homing_speed: 100
+homing_retract_dist: 0
+
+[tmc2209 stepper_y]
+uart_pin: PC11
+tx_pin: PC10
+run_current: 0.900
+stealthchop_threshold: 999999
+interpolate: False
+sense_resistor: 0.150
+uart_address: 2
+driver_SGTHRS: 122
+diag_pin: PC1
+
+[stepper_z]
+step_pin: PB0
+dir_pin: PC5
+enable_pin: !PB1
+microsteps: 64
+rotation_distance: 4
+endstop_pin: probe:z_virtual_endstop
+position_min: -4
+position_max: 261
+homing_speed: 100 
+
+[tmc2209 stepper_z]
+uart_pin: PC11
+tx_pin: PC10
+run_current: 1.000
+stealthchop_threshold: 999999
+interpolate: False
+sense_resistor: 0.150
+uart_address: 1
+diag_pin: PC2
+
+[thermistor sovol_thermistor]
+temperature1: 25
+resistance1: 94162
+beta: 4160
+
+[extruder]
+step_pin: PB3
+dir_pin: PB4
+enable_pin: !PD1
+microsteps: 32
+rotation_distance: 4.615
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PC8
+sensor_type: sovol_thermistor
+sensor_pin: PA0
+min_temp: 0
+max_temp: 300
+max_extrude_only_distance: 150.0
+pressure_advance: 0.027
+
+
+[tmc2209 extruder]
+uart_pin: PC11
+tx_pin: PC10
+run_current: 0.550
+stealthchop_threshold: 999999
+interpolate: False
+sense_resistor: 0.150
+uart_address: 3
+
+[heater_bed]
+heater_pin: PC9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PC4
+min_temp: 0
+max_temp: 130
+
+[fan]
+pin: PC6
+
+
+[heater_fan controller_fan]
+pin: PB15
+heater: heater_bed
+heater_temp: 45.0
+
+[heater_fan nozzle_cooling_fan]
+pin: PC7
+
+[probe]
+pin: PC14
+x_offset = 26.4
+y_offset = -19.0
+
+#z_offset: 0
+samples: 3
+samples_result: median
+samples_tolerance: 0.015
+samples_tolerance_retries: 5
+
+[safe_z_home]
+home_xy_position: 85,135
+speed: 100.0
+z_hop: 10
+z_hop_speed: 15
+
+[bed_mesh]
+speed: 175
+mesh_min: 26.4, 31
+mesh_max: 210, 201
+probe_count: 15, 15
+horizontal_move_z: 5
+algorithm: bicubic
+fade_start: 1
+fade_end: 10
+fade_target: 0
+
+#[display]
+#lcd_type: st7920
+#cs_pin: PB12
+#sclk_pin: PB13
+#sid_pin: PB15
+#encoder_pins: ^PB14, ^PB10
+#click_pin: ^!PB2
+
+[save_variables]
+filename: ~/printer_data/config/vars.cfg
+
+[idle_timeout]
+#gcode:
+#   A list of G-Code commands to execute on an idle timeout. See
+#   docs/Command_Templates.md for G-Code format. The default is to run
+#   "TURN_OFF_HEATERS" and "M84".
+timeout: 900
+#   Idle time (in seconds) to wait before running the above G-Code
+#   commands. The default is 600 seconds.
+


### PR DESCRIPTION
I spent a good amount of time figuring out the pin configurations for the SV06 using a BigTreeTech SKR Mini E3 v3, which I don't want to be lost.  Thought it would be helpful to others.  Not sure whether this is the right place for it, given Klipper can only have one printer.cfg.

This morning, I merged @bassamanator's klipper config with the pin configs for the SKR board, which is contained in this pull request.
