### PR TITLE
Add a minimum bed temperature of 0 degrees

### DIFF
--- a/cfgs/misc-macros.cfg
+++ b/cfgs/misc-macros.cfg
@@ -135,7 +135,7 @@ gcode:
         {% set startY = printer.configfile.settings.safe_z_home.home_xy_position[1]|float %}
     {% endif %}
 
-    {% set bedtempAlmost =  (bedtemp - 2)|int %}
+    {% set bedtempAlmost = (bedtemp - 2, 0)|max %}
     {% set hotendtempStepOne = 150|int %}
     {% set hotendtempStepTwo = 170|int %}
 


### PR DESCRIPTION
If the bed temperature is less than 2, the print job fails with an error message complaining about an invalid temperature. 
```
!! Requested temperature (-2.0) out of range (0.0:110.0)
```
This happens, for instance, when printing ABS where the bed is not supposed to be heated.

This change makes sure that the bed temperature cannot be negative.