### PR TITLE
Add config for 2 ADXL345 via RasPi pico

### DIFF
--- a/cfgs/adxl-rpi-pico-2x.cfg
+++ b/cfgs/adxl-rpi-pico-2x.cfg
@@ -1,0 +1,42 @@
+#####################################################################
+#   Config that supports a print head and a bed sensor at the same time
+#   This requires a Raspberry Pi Pico. Instructions:
+#   https://klipper.discourse.group/t/raspberry-pi-pico-adxl345-portable-resonance-measurement/1757/9
+#
+#   Recommended mounts: 
+#   https://www.printables.com/model/385334-sovol-sv06-adxl345-mount-printhead-and-bed
+#
+#   ADXL345 related Settings 
+#   https://www.klipper3d.org/Measuring_Resonances.html#adxl345
+#####################################################################
+
+[mcu RP2040]
+baud: 115200
+restart_method: command
+# Obtain definition by "ls -l /dev/serial/by-id/"
+serial: /dev/serial/by-id/usb-Klipper_rp2040_E66138935F154C28-if00
+
+[adxl345 head]
+cs_pin: RP2040:gpio1
+spi_bus: spi0a
+# update axes_map if your sensor is oriented differently. Note the print on your sensor.
+# -y, -z, x means that
+#  - the x axis of your printer corresponds to the sensor's negative y axis
+#  - the y axis of your printer corresponds to the sensor's negative z axis
+#  - the z axis of your printer corresponds to the sensor's x axis
+axes_map: -y, -z, x
+
+[adxl345 bed]
+cs_pin: RP2040:gpio9
+spi_bus: spi1a
+
+[resonance_tester]
+probe_points: 111.5, 116.5, 30
+accel_chip_x: adxl345 head
+accel_chip_y: adxl345 bed
+
+[gcode_macro ADX]
+description: Shortcut to ACCELEROMETER_QUERY for both sensors
+gcode:
+    ACCELEROMETER_QUERY CHIP=head
+    ACCELEROMETER_QUERY CHIP=bed

--- a/cfgs/adxl-rpi-pico-2x.cfg
+++ b/cfgs/adxl-rpi-pico-2x.cfg
@@ -1,7 +1,8 @@
 #####################################################################
 #   Config that supports a print head and a bed sensor at the same time
-#   This requires a Raspberry Pi Pico. Instructions:
-#   https://klipper.discourse.group/t/raspberry-pi-pico-adxl345-portable-resonance-measurement/1757/9
+#   This requires a Raspberry Pi Pico.
+#   Instructions: https://klipper.discourse.group/t/raspberry-pi-pico-adxl345-portable-resonance-measurement/1757/9
+#   TLDR Instructions: The two sensors should use the spi0a (GPIO 0-3) and spi1a (GPIO 9-12) buses, respectively.
 #
 #   Recommended mounts: 
 #   https://www.printables.com/model/385334-sovol-sv06-adxl345-mount-printhead-and-bed
@@ -31,9 +32,9 @@ cs_pin: RP2040:gpio9
 spi_bus: spi1a
 
 [resonance_tester]
-probe_points: 111.5, 116.5, 30
 accel_chip_x: adxl345 head
 accel_chip_y: adxl345 bed
+probe_points: 111.5, 111.5, 20
 
 [gcode_macro ADX]
 description: Shortcut to ACCELEROMETER_QUERY for both sensors

--- a/printer.cfg
+++ b/printer.cfg
@@ -10,6 +10,7 @@
 
 # NOTE Uncomment the ONE of the following lines if you're using an adxl345
 # [include ./cfgs/adxl-rp2040.cfg]
+# [include ./cfgs/adxl-rpi-pico-2x.cfg]
 # [include ./cfgs/adxl-direct.cfg]
 
 [mcu]


### PR DESCRIPTION
This adds a configuration supporting two ADXL345 sensors at the same time though a Raspberry Pi pico.

Resonance measurements for both the head and the bed can be done without having to change the sensors.

The two sensors should use the `spi0a` (GPIO 0-3) and `spi1a` (GPIO 9-12) buses, respectively, as described in this post: https://klipper.discourse.group/t/raspberry-pi-pico-adxl345-portable-resonance-measurement/1757/9

The configuration uses an axes mapping for the sensors and mounts here: https://www.printables.com/model/385334-sovol-sv06-adxl345-mount-printhead-and-bed