### PR TITLE
Avoid cooling down the extruder in PRINT_START

### DIFF
--- a/cfgs/misc-macros.cfg
+++ b/cfgs/misc-macros.cfg
@@ -136,8 +136,8 @@ gcode:
     {% endif %}
 
     {% set bedtempAlmost = (bedtemp - 2, 0)|max %}
-    {% set hotendtempStepOne = 150|int %}
-    {% set hotendtempStepTwo = 170|int %}
+    {% set hotendtempStepOne = ((hotendtemp, printer[printer.toolhead.extruder].temperature|int)|min, 150)|max %}
+    {% set hotendtempStepTwo = ((hotendtemp, printer[printer.toolhead.extruder].temperature|int)|min, 170)|max %}
 
     BED_MESH_PROFILE LOAD=default                                                ; NOTE if not using a mesh, comment out this line
     ADJUST_FILAMENT_SENSOR_STATUS ENABLE=1


### PR DESCRIPTION
The current `PRINT_START` macro heats the extruder to 150 degrees, then to 170, and finally to the target temperature. If the extruder is already hot, for instance from a filament change, this unnecessarily cools it down and wastes time.

This change only cools down the hotend if it's above the target temperature and then only to that temperature. It also maintains the staggered heating pattern if it's somewhere in between.

If the extruder was colder than 150 degrees, this change maintains the current behaviour.