### PR TITLE
Update misc-macros.cfg

### DIFF
--- a/cfgs/misc-macros.cfg
+++ b/cfgs/misc-macros.cfg
@@ -34,6 +34,15 @@ variable_pre_purge_prime_length: 1.40
 gcode:
     # Don't delete this section
 
+[gcode_macro SCREWS_TILT_ADJUST]
+# For use with "nylock mod" when solid spacers under bed are replaced with adjustable solution
+gcode:
+    G28
+    SCREWS_TILT_CALCULATE
+    G90                                    
+    G1 X{printer.toolhead.axis_maximum.x/2} F6000
+    M18
+
 [gcode_macro CONDITIONAL_BEEP]
 gcode:
     # Parameters


### PR DESCRIPTION
Added macro to run Screws Tilt Adjust, with homing first and moving extruder head to center of X axis at the end. This allows to remove plate from bed and access back left screw. Included is a note regarding nylock mod, that allows to use this command.