### PR TITLE
Update KAMP_Settings.cfg

### DIFF
--- a/cfgs/kamp/KAMP_Settings.cfg
+++ b/cfgs/kamp/KAMP_Settings.cfg
@@ -1,7 +1,7 @@
 # Below you can include specific configuration files depending on what you want KAMP to do:
 
 [include ./Adaptive_Meshing.cfg]       # Include to enable adaptive meshing configuration.
-# [include ./KAMP/Line_Purge.cfg]             # Include to enable adaptive line purging configuration.
+[include ./Line_Purge.cfg]             # Include to enable adaptive line purging configuration.
 
 [gcode_macro _KAMP_Settings]
 description: This macro contains all adjustable settings for KAMP 


### PR DESCRIPTION
Klipper cannot find the included Line Purge configuration file when included because there was an extra directory